### PR TITLE
Improve the sources checkout by using gitman

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 
 - Add a missing image used by the Euphorie package
 
+- Use gitman if it is available
+  [ale-rt]
+
 
 ## 1.0.0a4 (2025-02-20)
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ all: ## Update proto, compile it and install the resources
 var/prototype: # Get the latest version of the prototype
 	mkdir -p var
 	@if [ ! -d "var/prototype" ]; then \
-		git clone git@github.com:syslabcom/oira.prototype.git var/prototype; \
+		gitman update || (git clone git@github.com:syslabcom/oira.prototype.git var/prototype); \
 	else \
-		cd var/prototype && git pull; \
+		gitman update || (cd var/prototype && git pull); \
 	fi;
 
 .PHONY: update-proto
 update-proto: var/prototype  ## Update the prototype
-	@cd var/prototype && git pull
+	@gitman update || (cd var/prototype && git pull)
 
 .PHONY: jekyll
 jekyll: ## Compile the prototype with Jekyll

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ In order to properly update the package, you will need some development tools to
 - `rsync`
 - `Ruby`
 
+Optionally, you can install [`gitman`](https://gitman.readthedocs.io/en/latest/) to manage the checkouts.
+
 Updating the site is a three-step process.
 
 1. you need to fetch a fresh clone of the Euphorie prototype.

--- a/gitman.yml
+++ b/gitman.yml
@@ -1,15 +1,6 @@
-location: var/gitman
+location: var
 sources:
-  - repo: git@github.com:plone/plone.patternslib.git
-    name: plone.patternslib
-    rev: v2
+  - repo: git@github.com:syslabcom/oira.prototype.git
+    name: prototype
+    rev: main
     type: git
-    params:
-    sparse_paths:
-      -
-    links:
-      -
-    scripts:
-      -
-default_group: ''
-groups:


### PR DESCRIPTION
I prefer to use [`gitman`](https://gitman.readthedocs.io/en/latest/) because it uses a clone cache and the `gitman update` command is idempotent.

If you do not have `gitman` you will fallback to the already existing commands.