### PR TITLE
Script replacement: Also support version/release-level specific subdi…

### DIFF
--- a/news/+fix-script-replacement.bugfix.md
+++ b/news/+fix-script-replacement.bugfix.md
@@ -1,0 +1,2 @@
+Script replacement: Also support version/release-level specific subdirectories of the Patternslib script in prototype like alpha/, beta/, etc.
+[thet]

--- a/scripts/copy_resources.py
+++ b/scripts/copy_resources.py
@@ -70,9 +70,11 @@ def run():
     ):
         # We want to use the Plone provided plone.patternslib > 1,
         # which is a dependency of this package
-        text = filepath.read_text().replace(
-            "assets/oira/script/bundle.min.js",
+        #
+        text = re.sub(
+            r"assets/oira/script/.*bundle.min.js",
             "++resource++patternslib/bundle.min.js",
+            filepath.read_text()
         )
 
         # parse the file for the resources it links


### PR DESCRIPTION
…rectories of the Patternslib script in prototype like alpha/, beta/, etc.

Daniël sometimes places Patternslib scripts into subdirectories of `assets/oira/script/` like `assets/oira/script/beta` or `assets/oira/script/9.10.1` to test out different Patternslib versions. In that case the script path replacement to use the `plone.patternslib` one does not work anymore.

This PR fixes that problem.